### PR TITLE
Add compatibility with generic rustracing SpanConsumers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-rustracing-jaeger"
-version = "1.2.2"
+version = "1.3.0"
 authors = ["Takeru Ohta <phjgt308@gmail.com>", "Cloudflare Inc."]
 description = "Jaeger client library created on top of rustracing"
 homepage = "https://github.com/cloudflare/rustracing_jaeger"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ coveralls = {repository = "sile/rustracing"}
 hostname = "0.4.0"
 percent-encoding = "2.1.0"
 rand = "0.9.1"
-cf-rustracing = "1"
+cf-rustracing = "1.3"
 thrift_codec = "0.3.2"
 trackable = "1"
 tokio = { version = "1", features = ["net"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ coveralls = {repository = "sile/rustracing"}
 [dependencies]
 hostname = "0.4.0"
 percent-encoding = "2.1.0"
-rand = "0.9.1"
+rand = "0.10"
 cf-rustracing = "1.3"
 thrift_codec = "0.3.2"
 trackable = "1"

--- a/src/span.rs
+++ b/src/span.rs
@@ -57,10 +57,13 @@ pub type SpanHandle = cf_rustracing::span::SpanHandle<SpanContextState>;
 /// Finished span.
 pub type FinishedSpan = cf_rustracing::span::FinishedSpan<SpanContextState>;
 
-/// Span receiver.
+/// Unbounded [`tokio::sync::mpsc`] span receiver.
 pub type SpanReceiver = cf_rustracing::span::SpanReceiver<SpanContextState>;
 
-/// Sender of finished spans to the destination channel.
+/// Deprecated: alias for default [`SpanConsumer`](cf_rustracing::span::SpanConsumer)
+/// implementation.
+#[deprecated = "SpanSender is an implementation detail of rustracing. It should not be public."]
+#[expect(deprecated, reason = "alias is deprecated itself")]
 pub type SpanSender = cf_rustracing::span::SpanSender<SpanContextState>;
 
 /// Options for starting a span.

--- a/src/tracer.rs
+++ b/src/tracer.rs
@@ -1,4 +1,5 @@
 use cf_rustracing::sampler::{BoxSampler, Sampler};
+use cf_rustracing::span::SpanConsumer;
 use cf_rustracing::Tracer as InnerTracer;
 use std::borrow::Cow;
 use std::fmt;
@@ -11,13 +12,23 @@ pub struct Tracer {
     inner: InnerTracer<BoxSampler<SpanContextState>, SpanContextState>,
 }
 impl Tracer {
-    /// Makes a new `Tracer` instance.
+    /// Makes a new `Tracer` instance with an unbounded [`tokio::sync::mpsc`] channel.
     pub fn new<S>(sampler: S) -> (Self, SpanReceiver)
     where
         S: Sampler<SpanContextState> + Send + Sync + 'static,
     {
         let (inner, rx) = InnerTracer::new(sampler.boxed());
         (Tracer { inner }, rx)
+    }
+
+    /// Makes a new `Tracer` instance with a custom consumer implementation.
+    pub fn with_consumer<S, C>(sampler: S, consumer: C) -> Self
+    where
+        S: Sampler<SpanContextState> + Send + Sync + 'static,
+        C: SpanConsumer<SpanContextState> + 'static,
+    {
+        let inner = InnerTracer::with_consumer(sampler.boxed(), consumer);
+        Tracer { inner }
     }
 
     /// Clone with the given `sampler`.


### PR DESCRIPTION
Also updates some dependencies to avoid duplicates in the foundations tree.

Requires cloudflare/rustracing#9 to be released first. Includes a release commit for `cf-rustracing-jaeger 1.3.0`.